### PR TITLE
fix(csp): allow Google Fonts CDN so Roboto Condensed loads correctly

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -80,7 +80,8 @@ app.use(
       directives: {
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+        fontSrc: ["'self'", "https://fonts.gstatic.com"],
         imgSrc: ["'self'", "data:", "https:"],
         connectSrc: ["'self'", "https://api.stripe.com"],
         frameSrc: ["'none'"],


### PR DESCRIPTION
The security audit (cd8dc6b) tightened the CSP from disabled to self-only,
which inadvertently blocked fonts.googleapis.com (stylesheet) and
fonts.gstatic.com (font files), causing the browser to fall back to the
system sans-serif font instead of Roboto Condensed.

https://claude.ai/code/session_01EyhD7UJPHfS3wd1Kmy9fCU