### PR TITLE
fix: use Link for support page navigation to prevent full page reload

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -64,11 +64,11 @@ export default function Footer({ showShopNow = false }) {
         </div>
       </div>
       <div className="legal-links">
-        <a href="/termos-e-condicoes">Termos e Condições</a>
-        <a href="/politica-de-privacidade">Política de Privacidade</a>
-        <a href="/politica-de-cookies">Política de Cookies</a>
-        <a href="/direito-de-arrependimento">Direito de Arrependimento</a>
-        <a href="/politica-de-devolucoes">Devoluções e Reembolsos</a>
+        <Link to="/termos-e-condicoes">Termos e Condições</Link>
+        <Link to="/politica-de-privacidade">Política de Privacidade</Link>
+        <Link to="/politica-de-cookies">Política de Cookies</Link>
+        <Link to="/direito-de-arrependimento">Direito de Arrependimento</Link>
+        <Link to="/politica-de-devolucoes">Devoluções e Reembolsos</Link>
         <a href="https://www.livroreclamacoes.pt" target="_blank" rel="noreferrer">Livro de Reclamações</a>
         <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noreferrer">Resolução de Litígios</a>
       </div>

--- a/frontend/src/screens/ProductScreen.jsx
+++ b/frontend/src/screens/ProductScreen.jsx
@@ -25,6 +25,7 @@ export default function ProductScreen(props) {
   const [chosenSize, setChosenSize] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [imageIndex, setImageIndex] = useState(0);
+  const [currentIndex, setCurrentIndex] = useState(0);
 
   useScrollLock(isOpen);
 
@@ -36,6 +37,7 @@ export default function ProductScreen(props) {
 
   useEffect(() => {
     scrollTop();
+    setCurrentIndex(0);
     dispatch(detailsProduct(productId));
   }, [dispatch, productId]);
 
@@ -75,17 +77,17 @@ export default function ProductScreen(props) {
   };
 
   const next = () => {
-    document.getElementById("carousel-control-next").click();
+    setCurrentIndex((i) => (i + 1) % product.images.length);
   };
 
   const previous = () => {
-    document.getElementById("carousel-control-prev").click();
+    setCurrentIndex((i) => (i - 1 + product.images.length) % product.images.length);
   };
 
   const swipeHandlers = useSwipeable({
-    onSwipedLeft: () => next(),
-    onSwipedRight: () => previous(),
-    preventDefaultTouchmoveEvent: true,
+    onSwipedLeft: next,
+    onSwipedRight: previous,
+    preventScrollOnSwipe: true,
     trackMouse: true,
   });
 
@@ -127,9 +129,7 @@ export default function ProductScreen(props) {
                 {product.images.map((image, index) => (
                   <div
                     key={image}
-                    className={`carousel-item product-image ${
-                      image === product.images[0] && "active"
-                    }`}
+                    className={`carousel-item product-image ${index === currentIndex ? "active" : ""}`}
                   >
                     <Placeholder height="100%">
                       <div
@@ -148,38 +148,27 @@ export default function ProductScreen(props) {
                 ))}
               </div>
               <div className="arrows">
-                <a
-                  id="carousel-control-prev"
+                <button
                   className="carousel-control-prev"
-                  href="#productImageCarousel"
-                  role="button"
-                  data-slide="prev"
+                  onClick={previous}
+                  aria-label="Previous image"
                 >
-                  <span
-                    className="carousel-control-prev-icon"
-                    aria-hidden="true"
-                  ></span>
-                </a>
-                <a
-                  id="carousel-control-next"
+                  <span className="carousel-control-prev-icon" aria-hidden="true"></span>
+                </button>
+                <button
                   className="carousel-control-next"
-                  href="#productImageCarousel"
-                  role="button"
-                  data-slide="next"
+                  onClick={next}
+                  aria-label="Next image"
                 >
-                  <span
-                    className="carousel-control-next-icon"
-                    aria-hidden="true"
-                  ></span>
-                </a>
+                  <span className="carousel-control-next-icon" aria-hidden="true"></span>
+                </button>
               </div>
               <ol className="carousel-indicators">
                 {product.images.map((image, index) => (
                   <li
                     key={index}
-                    data-target="#productImageCarousel"
-                    data-slide-to={index}
-                    className={`${image === product.images[0] && "active"}`}
+                    className={index === currentIndex ? "active" : ""}
+                    onClick={() => setCurrentIndex(index)}
                   ></li>
                 ))}
               </ol>
@@ -189,8 +178,7 @@ export default function ProductScreen(props) {
                 <div
                   key={image}
                   className="image-preview"
-                  data-target="#productImageCarousel"
-                  data-slide-to={index}
+                  onClick={() => setCurrentIndex(index)}
                 >
                   <Placeholder height="100%">
                     <div

--- a/frontend/src/style/components/_carousel.scss
+++ b/frontend/src/style/components/_carousel.scss
@@ -62,6 +62,9 @@
   opacity: 0.5;
   transition: opacity 0.15s ease;
   right: 0;
+  background: none;
+  border: none;
+  padding: 0;
   &:focus {
     color: #fff;
     text-decoration: none;
@@ -92,6 +95,9 @@
   opacity: 0.5;
   transition: opacity 0.15s ease;
   left: 0;
+  background: none;
+  border: none;
+  padding: 0;
   &:focus {
     color: #fff;
     text-decoration: none;

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,3 @@
+# Todo
+
+- [ ] Dynamically remove the grey "loading" background when the page loads

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,0 @@
-# Todo
-
-- [ ] Dynamically remove the grey "loading" background when the page loads


### PR DESCRIPTION
Footer legal links were using <a href> instead of React Router <Link>,
causing a full page reload on each click and triggering the 1200ms
loading delay + 1.2s fade-in animation (~2.4s faded appearance).

https://claude.ai/code/session_01B5zW9ZoJYo8xcgkswQnCq9