### PR TITLE
Fix mobile admin passkey/logout button size mismatch and logout color

### DIFF
--- a/frontend/src/components/PasskeyRegister.jsx
+++ b/frontend/src/components/PasskeyRegister.jsx
@@ -39,15 +39,7 @@ export default function PasskeyRegister() {
     <div>
       {status === 'error' && <MessageBox variant="error">{error}</MessageBox>}
       {hasPasskey ? (
-        <div
-          style={{
-            display: 'inline-block',
-            border: '2px solid #4caf50',
-            color: '#4caf50',
-            padding: '0.5rem 1rem',
-            cursor: 'default',
-          }}
-        >
+        <div className="passkey-active-indicator">
           {t('admin.passkeyActive')}
         </div>
       ) : (

--- a/frontend/src/style/screens/_adminScreen.scss
+++ b/frontend/src/style/screens/_adminScreen.scss
@@ -92,12 +92,24 @@
   }
 }
 
+.passkey-active-indicator {
+  display: flex;
+  align-items: center;
+  border: 1px solid #4caf50;
+  color: #4caf50;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: default;
+}
+
 .admin-logout-btn {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0.35rem !important;
   border-radius: 0;
+  color: #1a1a1a;
 
   svg {
     display: block;


### PR DESCRIPTION
Passkey Active indicator was using inline styles with larger padding
(0.5rem 1rem) than the logout button (0.35rem), causing height mismatch
on mobile. Replaced inline styles with .passkey-active-indicator class
matching the button's padding/font-size/line-height. Also set explicit
color: #1a1a1a on .admin-logout-btn so the SVG icon renders black
instead of inheriting browser blue.

https://claude.ai/code/session_013y37jVaU7pSDkPMFLr8Xb5