### PR TITLE
Fix secondary button color on mobile (Safari blue border bug)

### DIFF
--- a/frontend/src/style/components/_button.scss
+++ b/frontend/src/style/components/_button.scss
@@ -22,6 +22,7 @@ button {
   }
   &.secondary {
     background-color: transparent;
+    color: $darkColor;
     &:hover:not(:disabled),
     &.active {
       color: white;


### PR DESCRIPTION
button.secondary had no explicit color set, causing mobile Safari to
render the border and text in its default blue. Adding color: $darkColor
ensures consistent black appearance across all platforms.

https://claude.ai/code/session_013y37jVaU7pSDkPMFLr8Xb5